### PR TITLE
Criação de sessão 'Textos e Discussões Relevantes' aos Links Úteis

### DIFF
--- a/Links Úteis/README.md
+++ b/Links Úteis/README.md
@@ -10,10 +10,10 @@ Eu vou começar com um editor de MarkDown, por que o github tem um editor muito 
 
 #### Livros e conteúdo sobre linguagens grátis e atualizados
 
-- WikiBooks: http://en.wikibooks.org/wiki/Subject:Computer_programming
-- Free Programming Books: https://github.com/vhf/free-programming-books/blob/master/free-programming-books.md
-- Learn X in Y Minutes: http://learnxinyminutes.com/
-- Programming, Motherfucker: http://programming-motherfucker.com/
+- [WikiBooks](http://en.wikibooks.org/wiki/Subject:Computer_programming)
+- [Free Programming Books](https://github.com/vhf/free-programming-books/blob/master/free-programming-books.md)
+- [Learn X in Y Minutes](http://learnxinyminutes.com/)
+- [Programming, Motherfucker](http://programming-motherfucker.com/)
 
 #### Textos e discussões relevantes e/ou comuns
 

--- a/Links Úteis/README.md
+++ b/Links Úteis/README.md
@@ -14,3 +14,9 @@ Eu vou começar com um editor de MarkDown, por que o github tem um editor muito 
 - Free Programming Books: https://github.com/vhf/free-programming-books/blob/master/free-programming-books.md
 - Learn X in Y Minutes: http://learnxinyminutes.com/
 - Programming, Motherfucker: http://programming-motherfucker.com/
+
+#### Textos e discussões relevantes e/ou comuns
+
+- [O que é Programação Orientada à
+  Objetos?](https://gist.github.com/robotlolita/11252065) - Texto do
+  [Quildreen Motta](https://github.com/robotlolita)


### PR DESCRIPTION
Existem alguns links que sempre colocamos na APDA em algumas
discussões pertinentes, principalmente criados pelos próprios
membros e ex-membros. Acho interessante organizar de uma forma
fácil para quem quiser ter acesso a esse material.
